### PR TITLE
Promisify fs methods to start using native Promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "env": {
     "node": true
   },
+  "globals": {
+    "Promise": true
+  },
   "rules": {
     "no-console": 2,
     "func-names": 0,

--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var fs = require('fs');
+var promisify = require('./promisify');
+
+var isCallbackMethod = function (key) {
+  return [
+    typeof fs[key] === 'function',
+    !key.match(/Sync$/),
+    !key.match(/^[A-Z]/),
+    !key.match(/^create/),
+    !key.match(/^(un)?watch/)
+  ].every(Boolean);
+};
+
+var promisifiedExists = function (path) {
+  return new Promise(function (resolve, reject) {
+    fs.exists(path, function (data) {
+      resolve(data);
+    });
+  });
+};
+
+var adaptMethod = function (name) {
+  var original = fs[name];
+  return promisify(original);
+};
+
+var adaptAllMethods = function () {
+  var adapted = {};
+
+  for (var key in fs) {
+    if (!fs.hasOwnProperty(key)) continue;
+
+    if (isCallbackMethod(key)) {
+      if (key === 'exists') {
+        // fs.exists() does not follow standard
+        // Node callback conventions, and has
+        // no error object in the callback
+        adapted.exists = promisifiedExists;
+      } else {
+        adapted[key] = adaptMethod(key);
+      }
+    } else {
+      adapted[key] = fs[key];
+    }
+  }
+
+  return adapted;
+};
+
+module.exports = adaptAllMethods();

--- a/lib/utils/promisify.js
+++ b/lib/utils/promisify.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = function (fn) {
+  return function () {
+    var i = 0;
+    var length = arguments.length;
+    var args = new Array(length);
+
+    for (; i < length; i++) {
+      args[i] = arguments[i];
+    }
+
+    return new Promise(function (resolve, reject) {
+      args.push(function (err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+
+      fn.apply(null, args);
+    });
+  };
+};

--- a/spec/utils/fs.spec.js
+++ b/spec/utils/fs.spec.js
@@ -1,0 +1,11 @@
+var fsNode = require('fs');
+var expect = require('chai').expect;
+var fs = require('../../lib/utils/fs');
+
+describe('fs', function () {
+  it('contains all the same keys as the node fs module', function () {
+    var originalKeys = Object.keys(fsNode);
+    var adaptedKeys = Object.keys(fs);
+    expect(adaptedKeys).to.deep.equal(originalKeys);
+  });
+});


### PR DESCRIPTION
Following #41 discussion. I'm starting with bringing in an in-house promisify function, and then creating an internal module that re-exports the `fs` module with the appropriate methods adapted to return Promises. All its other methods and properties are re-exported as-is.

This is the first step but there's a lot left - this just puts the base functions in a centralized location.

@szwacz let me know how this looks, for as much as it's worth so far. I tried to match the code style closely. There's a simple spec test in place to make sure all the same keys exist on our new internal module. This should expand as we go to make sure our Promisified functions work but I wanted to see if you had suggestions or input on that, ie. only the functions we use etc.

I ran a simple test in an uncommitted file with this code (in `util/demo.js`):

```js
const path = require('path')
const fs = require('./fs')

fs.stat(path.resolve(__dirname, 'matcher.js'))
  .then(stats => {
    console.log(stats)
    console.log('is a file: ', stats.isFile())
    console.log('is a directory: ', stats.isDirectory())
  }).catch(e => {
    console.error(e)
  })
```

... which resulted in ~~good vibes~~:

```
{ dev: 1688726541,
  mode: 33206,
  nlink: 1,
  uid: 0,
  gid: 0,
  rdev: 0,
  blksize: undefined,
  ino: 2533274790525215,
  size: 2136,
  blocks: undefined,
  atime: 2017-03-08T03:50:02.313Z,
  mtime: 2017-03-08T03:50:02.321Z,
  ctime: 2017-03-08T03:50:02.321Z,
  birthtime: 2017-03-08T03:50:02.313Z }
is a file:  true
is a directory:  false
```

Side note, all the symlink tests fail since I'm on Windows, or at least I assumed that's why. Could be permissions.