### PR TITLE
Adds symlinks search option to find.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Finds in directory specified by `path` all files fulfilling `searchOptions`. Ret
 * `files` (default `true`) whether or not should search for files.
 * `directories` (default `false`) whether or not should search for directories.
 * `recursive` (default `true`) whether the whole directory tree should be searched recursively, or only one-level of given directory (excluding it's subdirectories).
+* `symlinks` (default `false`) whether or not should report symlinks found.
 
 **returns:**  
 `Array` of found paths.
@@ -275,6 +276,9 @@ jetpack.find('foo', { matching: './*.txt' });
 // This line does the same as the above, but has better performance
 // (skips looking in subdirectories)
 jetpack.find('foo', { matching: '*.txt', recursive: false });
+
+// finds all dirs (including symlinked dirs) beginning with `plugin-*` in `node_modules`
+jetpack.find('node_modules', { matching: 'plugin-*', recursive: false, files: false, directories: true, symlinks: true });
 
 // Path parameter might be omitted and CWD is used as path in that case.
 const myStuffDir = jetpack.cwd('my-stuff');

--- a/lib/find.js
+++ b/lib/find.js
@@ -14,6 +14,7 @@ const validateInput = (methodName, path, options) => {
     files: ['boolean'],
     directories: ['boolean'],
     recursive: ['boolean'],
+    symlinks: ['boolean'],
   });
 };
 
@@ -28,6 +29,9 @@ const normalizeOptions = (options) => {
   }
   if (opts.recursive === undefined) {
     opts.recursive = true;
+  }
+  if (opts.symlinks === undefined) {
+    opts.symlinks = false;
   }
   return opts;
 };
@@ -71,7 +75,8 @@ const findSync = (path, options) => {
   }, (itemPath, item) => {
     if (itemPath !== path && matchesAnyOfGlobs(itemPath)) {
       if ((item.type === 'file' && options.files === true)
-        || (item.type === 'dir' && options.directories === true)) {
+        || (item.type === 'dir' && options.directories === true)
+        || (item.type === 'symlink' && options.symlinks === true)) {
         foundInspectObjects.push(item);
       }
     }
@@ -116,7 +121,8 @@ const findAsync = (path, options) => {
       if (data && data.path !== path && matchesAnyOfGlobs(data.path)) {
         const item = data.item;
         if ((item.type === 'file' && options.files === true)
-          || (item.type === 'dir' && options.directories === true)) {
+          || (item.type === 'dir' && options.directories === true)
+          || (item.type === 'symlink' && options.symlinks === true)) {
           foundInspectObjects.push(item);
         }
       }

--- a/spec/find.spec.js
+++ b/spec/find.spec.js
@@ -265,6 +265,33 @@ describe('find', () => {
     });
   });
 
+  describe("doesn't look for symlinks by default", () => {
+    const preparations = () => {
+      fse.outputFileSync('file', 'abc');
+      fse.mkdirsSync('dir');
+      jetpack.symlink('file', 'symfile');
+      jetpack.symlink('dir', 'symdir');
+    };
+
+    const expectations = (found) => {
+      expect(found).to.eql(['file']);
+    };
+
+    it('sync', () => {
+      preparations();
+      expectations(jetpack.find({ matching: '*' }));
+    });
+
+    it('async', (done) => {
+      preparations();
+      jetpack.findAsync({ matching: '*' })
+      .then((found) => {
+        expectations(found);
+        done();
+      });
+    });
+  });
+
   describe('can look for files and directories', () => {
     const preparations = () => {
       fse.outputFileSync('a/b/foo1', 'abc');
@@ -392,6 +419,33 @@ describe('find', () => {
         files: false,
         directories: false,
       })
+      .then((found) => {
+        expectations(found);
+        done();
+      });
+    });
+  });
+
+  describe('can look for symlinks', () => {
+    const preparations = () => {
+      fse.outputFileSync('file', 'abc');
+      fse.mkdirsSync('dir');
+      jetpack.symlink('file', 'symfile');
+      jetpack.symlink('dir', 'symdir');
+    };
+
+    const expectations = (found) => {
+      expect(found).to.eql(['file', 'symdir', 'symfile']);
+    };
+
+    it('sync', () => {
+      preparations();
+      expectations(jetpack.find({ matching: '*', symlinks: true }));
+    });
+
+    it('async', (done) => {
+      preparations();
+      jetpack.findAsync({ matching: '*', symlinks: true })
       .then((found) => {
         expectations(found);
         done();
@@ -566,6 +620,15 @@ describe('find', () => {
             expect(() => {
               test.method('abc', { recursive: 1 });
             }).to.throw(`Argument "options.recursive" passed to ${test.methodName}([path], options) must be a boolean. Received number`);
+          });
+        });
+      });
+      describe('"symlinks" argument', () => {
+        tests.forEach((test) => {
+          it(test.type, () => {
+            expect(() => {
+              test.method('abc', { symlinks: 1 });
+            }).to.throw(`Argument "options.symlinks" passed to ${test.methodName}([path], options) must be a boolean. Received number`);
           });
         });
       });


### PR DESCRIPTION
Had this use case pop up.

I have a [library](https://github.com/infinitered/gluegun) which allows plugins to be loaded from the `node_modules` directory.

As a node dev, you tend to use `npm link` to drop your WIP packages into a project and when you do, they arrive as `symlinks`.

In `fs-jetpack`, the `list()` call will return them, but I needed to use the `matcher` functionality offered by `find`.

So this PR adds `symlinks: true` to the search options of `find`.

It's off by default.

Is this something you'd welcome?  Did I overlook anything?

Cheers!
