### PR TITLE
Find no longer crashes on ENOENT

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -83,7 +83,7 @@ const findSync = (path, options) => {
       }
     },
     (itemPath, item) => {
-      if (itemPath !== path && matchesAnyOfGlobs(itemPath)) {
+      if (item && itemPath !== path && matchesAnyOfGlobs(itemPath)) {
         if (
           (item.type === "file" && options.files === true) ||
           (item.type === "dir" && options.directories === true)

--- a/lib/find.js
+++ b/lib/find.js
@@ -136,7 +136,12 @@ const findAsync = (path, options) => {
       })
       .on("readable", () => {
         const data = walker.read();
-        if (data && data.path !== path && matchesAnyOfGlobs(data.path)) {
+        if (
+          data &&
+          data.item &&
+          data.path !== path &&
+          matchesAnyOfGlobs(data.path)
+        ) {
           const item = data.item;
           if (
             (item.type === "file" && options.files === true) ||


### PR DESCRIPTION
`treeWalker.sync` creates an `item` object by calling `inspect.sync`, which can return undefined if the file is not found.  This can happen in a few situations when walking a directory tree, I specifically experienced it when the `MAX_PATH` limit of 255 was exceeded in a VFS context, though there likely are other situations where a directory may report a child file but inspect would throw an `ENOENT` file when trying to inspect that file.

This simple fix just verifies that the item passed to the `treeWalker.sync` callback in `findSync` is truthy before attempting to access its properties, so in a situation where an `ENOENT` error occurs while walking a file tree we simply ignore the error and continue walking the tree.  I think this is the desired behavior for `find`, but some kind of reporting of the error may be prudent :question: 