### PR TITLE
Use rimraf (fixes #80)

### DIFF
--- a/lib/remove.js
+++ b/lib/remove.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const pathUtil = require("path");
-const fs = require("./utils/fs");
+const rimraf = require('rimraf');
+const promisify = require('./utils/promisify');
+const promisifiedRimraf = promisify(rimraf);
 const validate = require("./utils/validate");
-const list = require("./list");
 
 const validateInput = (methodName, path) => {
   const methodSignature = `${methodName}([path])`;
@@ -15,103 +15,15 @@ const validateInput = (methodName, path) => {
 // ---------------------------------------------------------
 
 const removeSync = path => {
-  try {
-    // Assume the path is a file and just try to remove it.
-    fs.unlinkSync(path);
-  } catch (err) {
-    if (
-      err.code === "EPERM" ||
-      err.code === "EISDIR" ||
-      err.code === "ENOTEMPTY"
-    ) {
-      // Must delete everything inside the directory first.
-      list.sync(path).forEach(filename => {
-        removeSync(pathUtil.join(path, filename));
-      });
-      // Everything inside directory has been removed,
-      // it's safe now do go for the directory itself.
-      fs.rmdirSync(path);
-    } else if (err.code === "ENOENT") {
-      // File already doesn't exist. We're done.
-    } else {
-      // Something unexpected happened. Rethrow original error.
-      throw err;
-    }
-  }
+  rimraf.sync(path, { disableGlob: true });
 };
 
 // ---------------------------------------------------------
 // Async
 // ---------------------------------------------------------
 
-const removeAsyncInternal = (path, retryCount) => {
-  return new Promise((resolve, reject) => {
-    const retryInAWhileOrFail = err => {
-      if (retryCount === 3) {
-        // Too many retries already. Fail.
-        reject(err);
-      } else {
-        // Try the same action after some pause.
-        setTimeout(() => {
-          removeAsyncInternal(path, retryCount + 1).then(resolve, reject);
-        }, 100);
-      }
-    };
-
-    const removeEverythingInsideDirectory = () => {
-      return list.async(path).then(filenamesInsideDir => {
-        const promises = filenamesInsideDir.map(filename => {
-          return removeAsyncInternal(pathUtil.join(path, filename), 0);
-        });
-        return Promise.all(promises);
-      });
-    };
-
-    // Assume the path is a file and just try to remove it.
-    fs.unlink(path)
-      .then(resolve)
-      .catch(err => {
-        if (err.code === "EBUSY") {
-          retryInAWhileOrFail(err);
-        } else if (
-          err.code === "EPERM" ||
-          err.code === "EISDIR" ||
-          err.code === "ENOTEMPTY"
-        ) {
-          // File deletion attempt failed. Probably it's not a file, it's a directory.
-          // So try to proceed with that assumption.
-          removeEverythingInsideDirectory()
-            .then(() => {
-              // Now go for the directory.
-              return fs.rmdir(path);
-            })
-            .then(resolve)
-            .catch(err2 => {
-              if (
-                err2.code === "EBUSY" ||
-                err2.code === "EPERM" ||
-                err2.code === "ENOTEMPTY"
-              ) {
-                // Failed again. This might be due to other processes reading
-                // something inside the directory. Let's take a nap and retry.
-                retryInAWhileOrFail(err2);
-              } else {
-                reject(err2);
-              }
-            });
-        } else if (err.code === "ENOENT") {
-          // File already doesn't exist. We're done.
-          resolve();
-        } else {
-          // Something unexpected happened. Rethrow original error.
-          reject(err);
-        }
-      });
-  });
-};
-
 const removeAsync = path => {
-  return removeAsyncInternal(path, 0);
+  return promisifiedRimraf(path, { disableGlob: true });
 };
 
 // ---------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "2.2.1",
   "author": "Jakub Szwacz <jakub@szwacz.com>",
   "dependencies": {
-    "minimatch": "^3.0.2"
+    "minimatch": "^3.0.2",
+    "rimraf": "^2.6.3"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",


### PR DESCRIPTION
Fixes #80. Replaces current `remove()` code with [rimraf](https://github.com/isaacs/rimraf).

Note: I've decided to use `{ disableGlob: true }` as an option to `rimraf` because the previous code for `remove` didn't do anything with globs - and also, I don't want to make a breaking change with this PR, only a fix for intermittent errors.