### PR TITLE
Fix table of contents in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Check out [EXAMPLES](EXAMPLES.md) to see few snippets what it can do.
 [inspect](#inspectpath-options)  
 [inspectTree](#inspecttreepath-options)  
 [list](#listpath)  
-[move](#movefrom-to)  
+[move](#movefrom-to-options)  
 [path](#pathparts)  
 [read](#readpath-returnas)  
 [remove](#removepath)  
-[rename](#renamepath-newname)  
+[rename](#renamepath-newname-options)  
 [symlink](#symlinksymlinkvalue-path)  
 [write](#writepath-data-options)
 


### PR DESCRIPTION
After the new updates to `move` and `rename`, the links for them stopped working... :sweat_smile: 