### PR TITLE
fix: add default value for find matches option

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Finds in directory specified by `path` all files fulfilling `searchOptions`. Ret
 `path` (optional, defaults to `'.'`) path to start search in (all subdirectories will be searched).  
 `searchOptions` is an `Object` with possible fields:
 
-- `matching` glob patterns of files you want to find ([all possible globs are described further in this readme](#matching-patterns)).
+- `matching` (default `*`) glob patterns of files you want to find ([all possible globs are described further in this readme](#matching-patterns)).
 - `files` (default `true`) whether or not should search for files.
 - `directories` (default `false`) whether or not should search for directories.
 - `recursive` (default `true`) whether the whole directory tree should be searched recursively, or only one-level of given directory (excluding it's subdirectories).
@@ -356,6 +356,9 @@ Finds in directory specified by `path` all files fulfilling `searchOptions`. Ret
 **examples:**
 
 ```javascript
+// Finds all files inside 'foo' directory and its subdirectories
+jetpack.find("foo");
+
 // Finds all files which has 2015 in the name
 jetpack.find("my-work", { matching: "*2015*" });
 

--- a/lib/find.js
+++ b/lib/find.js
@@ -21,6 +21,9 @@ const validateInput = (methodName, path, options) => {
 const normalizeOptions = options => {
   const opts = options || {};
   // defaults:
+  if (opts.matches === undefined) {
+    opts.matches = '*';
+  }
   if (opts.files === undefined) {
     opts.files = true;
   }

--- a/lib/find.js
+++ b/lib/find.js
@@ -21,8 +21,8 @@ const validateInput = (methodName, path, options) => {
 const normalizeOptions = options => {
   const opts = options || {};
   // defaults:
-  if (opts.matches === undefined) {
-    opts.matches = '*';
+  if (opts.matching === undefined) {
+    opts.matching = "*";
   }
   if (opts.files === undefined) {
     opts.files = true;

--- a/spec/find.spec.ts
+++ b/spec/find.spec.ts
@@ -32,6 +32,31 @@ describe("find", () => {
     });
   });
 
+  describe('defaults to "*" if no matching is provided', () => {
+    const preparations = () => {
+      fse.outputFileSync("a/b/file.txt", "abc");
+      fse.outputFileSync("a/b/file.bin", "abc");
+    };
+
+    const expectations = (found: string[]) => {
+      const normalizedPaths = helper.osSep(["a/b/file.bin", "a/b/file.txt"]);
+      expect(found).to.eql(normalizedPaths);
+    };
+
+    it("sync", () => {
+      preparations();
+      expectations(jetpack.find("a"));
+    });
+
+    it("async", done => {
+      preparations();
+      jetpack.findAsync("a").then(found => {
+        expectations(found);
+        done();
+      });
+    });
+  });
+
   describe("if recursive=false will exclude subfolders from search", () => {
     const preparations = () => {
       fse.outputFileSync("x/file.txt", "abc");


### PR DESCRIPTION
So that I can use `fs.find()` instead of `fs.find({ matching: '*' })`, more clean.